### PR TITLE
Add repo retention count

### DIFF
--- a/docs/config/policies.md
+++ b/docs/config/policies.md
@@ -91,6 +91,20 @@ Interval duration to look back before deleting an artifact.
     ```
 
 !!! abstract "Environment variables"
+    * `ATFCLNP_POLICIES_<KEY>_RETENTIONCOUNT`
+
+### `retentionCount`
+
+The minimum number of artifacts to retain regardless of other policies.
+
+!!! example "Config file"
+    ```yaml
+    policies:
+      - name: "mypolicy"
+        retentionCount: 3
+    ```
+
+!!! abstract "Environment variables"
     * `ATFCLNP_POLICIES_<KEY>_RETENTION`
 
 ### `lastModified`
@@ -162,7 +176,6 @@ during the cleanup process.
         name: "mypolicy"
         docker:
           keepSemver: true
-          repoRetentionCount: 3
           exclude:
             - "latest"
     ```
@@ -170,10 +183,8 @@ during the cleanup process.
 !!! abstract "Environment variables"
     * `ATFCLNP_POLICIES_<KEY>_DOCKER_KEEPSEMVER`
     * `ATFCLNP_POLICIES_<KEY>_DOCKER_EXCLUDE`
-    * `ATFCLNP_POLICIES_<KEY>_DOCKER_REPORETENTIONCOUNT`
 
 | Name                 | Default       | Description   |
 |----------------------|---------------|---------------|
 | `keepSemver`         |               | Do not remove tags matching a semver compliant pattern |
-| `repoRetentionCount` |               | The number of images that should be kept in each docker repository regardless of `lastModified` and `lastDownloaded` |
 | `exclude`            |               | List of tags matching an expression to exclude |

--- a/docs/config/policies.md
+++ b/docs/config/policies.md
@@ -14,6 +14,7 @@ policies:
     lastDownloaded: true
     docker:
       keepSemver: true
+      repoRetentionCount: 3
       exclude:
         - "latest"
   -
@@ -161,6 +162,7 @@ during the cleanup process.
         name: "mypolicy"
         docker:
           keepSemver: true
+          repoRetentionCount: 3
           exclude:
             - "latest"
     ```
@@ -168,8 +170,10 @@ during the cleanup process.
 !!! abstract "Environment variables"
     * `ATFCLNP_POLICIES_<KEY>_DOCKER_KEEPSEMVER`
     * `ATFCLNP_POLICIES_<KEY>_DOCKER_EXCLUDE`
+    * `ATFCLNP_POLICIES_<KEY>_DOCKER_REPORETENTIONCOUNT`
 
-| Name               | Default       | Description   |
-|--------------------|---------------|---------------|
-| `keepSemver`       |               | Do not remove tags matching a semver compliant pattern |
-| `exclude`          |               | List of tags matching an expression to exclude |
+| Name                 | Default       | Description   |
+|----------------------|---------------|---------------|
+| `keepSemver`         |               | Do not remove tags matching a semver compliant pattern |
+| `repoRetentionCount` |               | The number of images that should be kept in each docker repository regardless of `lastModified` and `lastDownloaded` |
+| `exclude`            |               | List of tags matching an expression to exclude |

--- a/docs/usage/basic-example.md
+++ b/docs/usage/basic-example.md
@@ -26,6 +26,7 @@ policies:
     lastDownloaded: true
     docker:
       keepSemver: true
+      repoRetentionCount: 1
       exclude:
         - "latest"
   -

--- a/docs/usage/basic-example.md
+++ b/docs/usage/basic-example.md
@@ -22,11 +22,11 @@ policies:
       - "docker-prod-local"
     schedule: "*/30 * * * *"
     retention: "2160h" # 90d
+    retentionCount: 1
     lastModified: true
     lastDownloaded: true
     docker:
       keepSemver: true
-      repoRetentionCount: 1
       exclude:
         - "latest"
   -

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -49,6 +49,7 @@ func TestLoadFile(t *testing.T) {
 						},
 						Schedule:       "*/30 * * * *",
 						Retention:      utl.NewDuration(720 * time.Hour),
+						RetentionCount: utl.NewInt(3),
 						LastModified:   utl.NewTrue(),
 						LastDownloaded: utl.NewTrue(),
 						Common:         (&PolicyCommon{}).GetDefaults(),
@@ -68,6 +69,7 @@ func TestLoadFile(t *testing.T) {
 						},
 						Schedule:       "*/30 * * * * *",
 						Retention:      utl.NewDuration(24 * time.Hour),
+						RetentionCount: utl.NewInt(3),
 						LastModified:   utl.NewTrue(),
 						LastDownloaded: utl.NewTrue(),
 						Common: &PolicyCommon{

--- a/internal/config/fixtures/config.test.yml
+++ b/internal/config/fixtures/config.test.yml
@@ -9,8 +9,8 @@ policies:
       - docker-me-local
     schedule: "*/30 * * * *"
     retention: 720h
+    repoRetentionCount: 3
     docker:
-      repoRetentionCount: 3
       exclude:
         - "latest"
   -
@@ -21,6 +21,7 @@ policies:
       - generic-local
     schedule: "*/30 * * * * *"
     retention: 24h
+    repoRetentionCount: 3
     common:
       include:
         - "prod/*"

--- a/internal/config/fixtures/config.test.yml
+++ b/internal/config/fixtures/config.test.yml
@@ -10,6 +10,7 @@ policies:
     schedule: "*/30 * * * *"
     retention: 720h
     docker:
+      repoRetentionCount: 3
       exclude:
         - "latest"
   -

--- a/internal/config/policies.go
+++ b/internal/config/policies.go
@@ -15,6 +15,7 @@ type Policy struct {
 	Repos          []string       `yaml:"repos,omitempty" json:"repos,omitempty" validate:"required"`
 	Schedule       string         `yaml:"schedule,omitempty" json:"schedule,omitempty" validate:"required"`
 	Retention      *time.Duration `yaml:"retention,omitempty" json:"retention,omitempty" validate:"required"`
+	RetentionCount *int           `yaml:"retentionCount,omitempty" json:"retentionCount,omitempty" validate:"required"`
 	LastModified   *bool          `yaml:"lastModified,omitempty" json:"lastModified,omitempty" validate:"required"`
 	LastDownloaded *bool          `yaml:"lastDownloaded,omitempty" json:"lastDownloaded,omitempty" validate:"required"`
 	Common         *PolicyCommon  `yaml:"common,omitempty" json:"common,omitempty"`

--- a/internal/config/policy_docker.go
+++ b/internal/config/policy_docker.go
@@ -6,8 +6,9 @@ import (
 
 // PolicyDocker holds docker's policy configuration
 type PolicyDocker struct {
-	KeepSemver *bool    `yaml:"keepSemver,omitempty" json:"keepSemver,omitempty"`
-	Exclude    []string `yaml:"exclude,omitempty" json:"exclude,omitempty"`
+	KeepSemver         *bool    `yaml:"keepSemver,omitempty" json:"keepSemver,omitempty"`
+	RepoRetentionCount *int     `yaml:"repoRetentionCount,omitempty" json:"repoRetentionCount,omitempty" validate:"required"`
+	Exclude            []string `yaml:"exclude,omitempty" json:"exclude,omitempty"`
 }
 
 // GetDefaults gets the default values

--- a/internal/config/policy_docker.go
+++ b/internal/config/policy_docker.go
@@ -6,9 +6,8 @@ import (
 
 // PolicyDocker holds docker's policy configuration
 type PolicyDocker struct {
-	KeepSemver         *bool    `yaml:"keepSemver,omitempty" json:"keepSemver,omitempty"`
-	RepoRetentionCount *int     `yaml:"repoRetentionCount,omitempty" json:"repoRetentionCount,omitempty" validate:"required"`
-	Exclude            []string `yaml:"exclude,omitempty" json:"exclude,omitempty"`
+	KeepSemver *bool    `yaml:"keepSemver,omitempty" json:"keepSemver,omitempty"`
+	Exclude    []string `yaml:"exclude,omitempty" json:"exclude,omitempty"`
 }
 
 // GetDefaults gets the default values

--- a/internal/job/common.go
+++ b/internal/job/common.go
@@ -47,7 +47,7 @@ func (j *Job) cleanupCommonRepo(config artifactory.RepoConfiguration) *CleanupRe
 	sublog.Info().Msgf("%d files found", len(files))
 
 	// Iterate over files
-	for _, file := range files {
+	for index, file := range files {
 		filelog := sublog.With().
 			Str("file", path.Join(file.Path, file.Name)).
 			Str("size", units.HumanSize(float64(file.Size))).
@@ -70,6 +70,11 @@ func (j *Job) cleanupCommonRepo(config artifactory.RepoConfiguration) *CleanupRe
 		}
 		if *j.Policy.LastDownloaded && currentDate.Sub(lastDownloaded) < *j.Policy.Retention {
 			filelog.Debug().Msg("This file is not old enough to be deleted. Skipping...")
+			continue
+		}
+
+		if *j.Policy.RetentionCount > 0 && len(files)-index <= *j.Policy.RetentionCount {
+			filelog.Debug().Msg("This image is within the specified retention count for this repository. Skipping...")
 			continue
 		}
 

--- a/internal/job/docker.go
+++ b/internal/job/docker.go
@@ -99,7 +99,7 @@ func (j *Job) cleanupDockerRepo(config artifactory.RepoConfiguration) *CleanupRe
 				continue
 			}
 
-			if *j.Policy.Docker.RepoRetentionCount > 0 && len(tags.Tags)-index <= *j.Policy.Docker.RepoRetentionCount {
+			if *j.Policy.RetentionCount > 0 && len(tags.Tags)-index <= *j.Policy.RetentionCount {
 				tagDateLog.Debug().Msg("This image is within the specified retention count for this repository. Skipping...")
 				continue
 			}

--- a/internal/job/docker.go
+++ b/internal/job/docker.go
@@ -47,7 +47,7 @@ func (j *Job) cleanupDockerRepo(config artifactory.RepoConfiguration) *CleanupRe
 		}
 
 		// Iterate over tags
-		for _, tag := range tags.Tags {
+		for index, tag := range tags.Tags {
 			tagLog := dockerRepoLog.With().Str("tag", tag).Logger()
 
 			// Image size
@@ -96,6 +96,11 @@ func (j *Job) cleanupDockerRepo(config artifactory.RepoConfiguration) *CleanupRe
 			}
 			if *j.Policy.LastDownloaded && currentDate.Sub(lastDownloaded) < *j.Policy.Retention {
 				tagDateLog.Debug().Msg("This tag is not old enough to be deleted. Skipping...")
+				continue
+			}
+
+			if *j.Policy.Docker.RepoRetentionCount > 0 && len(tags.Tags)-index <= *j.Policy.Docker.RepoRetentionCount {
+				tagDateLog.Debug().Msg("This image is within the specified retention count for this repository. Skipping...")
 				continue
 			}
 

--- a/pkg/utl/utl.go
+++ b/pkg/utl/utl.go
@@ -42,6 +42,11 @@ func NewTrue() *bool {
 	return &b
 }
 
+// NewInt returns a pointer to the int passed in
+func NewInt(i int) *int {
+	return &i
+}
+
 // NewDuration returns a duration pointer
 func NewDuration(duration time.Duration) *time.Duration {
 	return &duration


### PR DESCRIPTION
This new configuration value adds the ability to _not_ delete `<repoRetentionCount>` number of images from each docker repository within the Artifactory repository. Without this, if all images have not been downloaded or modified within the `retention` specified, all images will be removed for that docker repository.

My use case (though I'm sure there are others) is that I'm using a specific image as a _base_ for building other images. However, every developer has already downloaded the image months in the past, and all production nodes have also downloaded the images months in the past. If a production node goes down and a new one needs to be spun up, or a new developer joins the team, this image still needs to exist within Artifactory and should therefore not be deleted. This `repoRetentionCount` configuration value provides the ability for that image to _never_ get deleted until it is updated or replaced by a newer version.